### PR TITLE
デフォルトの挙動を変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,15 @@ refreshXcode is a script to delete Xcode's cache.
 - ~/Library/Developer/Xcode/iOS DeviceSupport
 - ~/Library/Developer/Xcode/Archives
 
-![cap](https://user-images.githubusercontent.com/3356758/37102109-76ed35b8-226a-11e8-9609-9ca69bb796f8.gif)
+![cap](https://user-images.githubusercontent.com/3356758/37200039-eadb8da0-23c6-11e8-857f-d66487eb2405.gif)
 
 # USAGE
 
 ```bash
-# The default behavior is to delete ~/Library/Developer/Xcode/DerivedData.
+# The default behavior is to delete the following directories.
+#  ~/Library/Developer/Xcode/DerivedData
+#  ~/Library/Developer/Xcode/iOS DeviceSupport
+#  ~/Library/Developer/Xcode/Archives
 refreshXcode
 # dry-run
 refreshXcode -n
@@ -19,12 +22,16 @@ refreshXcode -n
 refreshXcode -h
 ```
 
+You can also delete them individually by specifying options.
+
 ```bash
+# If you add -d option, add ~/Library/Developer/Xcode/DerivedData to be deleted.
+refreshXcode -d
 # If you add -s option, add ~/Library/Developer/Xcode/iOS DeviceSupport to be deleted. 
 refreshXcode -s 
 # If you add -b option, add ~/Library/Developer/Xcode/Archives to be deleted. 
-refreshXcode -b 
-# Both
+refreshXcode -b
+# Multiple
 refreshXcode -sb
 ```
 

--- a/bin/refreshXcode
+++ b/bin/refreshXcode
@@ -6,9 +6,9 @@
 DERIVED_DATA_DIR=~/Library/Developer/Xcode/DerivedData
 DEVICE_SUPPORT_DIR=~/Library/Developer/Xcode/iOS\ DeviceSupport
 ARCHIVE_DIR=~/Library/Developer/Xcode/Archives
-DIRS="$DERIVED_DATA_DIR"
+DIRS="${DERIVED_DATA_DIR},${DEVICE_SUPPORT_DIR},${ARCHIVE_DIR}"
 PROGNAME=$(basename $0)
-VERSION="1.6"
+VERSION="1.7"
 COLOR_ESC="\e["
 COLOR_ESC_END="m"
 WHITE_UNDER="${COLOR_ESC}31;;4${COLOR_ESC_END}"
@@ -20,8 +20,9 @@ COLOR_GREEN=${COLOR_ESC}32${COLOR_ESC_END}
 COLOR_PURPLE=${COLOR_ESC}35${COLOR_ESC_END}
 COLOR_CYAN=${COLOR_ESC}36${COLOR_ESC_END}
 COLOR_OFF=${COLOR_ESC}${COLOR_ESC_END}
-IS_CONTAIN_DEVICE_SUPPORT=false
-IS_CONTAIN_ARCHIVE=false
+IS_CONTAIN_DEVICE_SUPPORT=true
+IS_CONTAIN_ARCHIVE=true
+IS_CONTAIN_DERIVED_DIR=true
 # echo -eを使うと環境に依存するため
 # 色を出力する時はこちらを利用
 ECHO=printf
@@ -141,12 +142,25 @@ function usage()
 {
   echo "Usage: $PROGNAME [OPTION]"
   echo 
-  ${ECHO} "The default behavior is to delete ${COLOR_CYAN}~/Library/Developer/Xcode/DerivedData${COLOR_OFF} .\n"
-  echo "You can add directories to be deleted with the options."
+  echo "The default behavior is to delete the following directories."
+  ${ECHO} " ${COLOR_CYAN}~/Library/Developer/Xcode/DerivedData${COLOR_OFF}\n"
+  ${ECHO} " ${COLOR_CYAN}~/Library/Developer/Xcode/iOS DeviceSupport${COLOR_OFF}\n"
+  ${ECHO} " ${COLOR_CYAN}~/Library/Developer/Xcode/Archives${COLOR_OFF}\n"
+  echo
+  echo "You can also delete them individually by specifying options."
+  echo
+  echo "e.g."
+  echo
+  echo "Only ~/Library/Developer/Xcode/DerivedData"
+  ${ECHO} "${COLOR_GREEN}$ refreshXcode -s${COLOR_OFF}\n"
+  echo
+  echo "~/Library/Developer/Xcode/DerivedData and ~/Library/Developer/Xcode/Archives"
+  ${ECHO} "${COLOR_GREEN}$ refreshXcode -sb${COLOR_OFF}\n"
   echo
   echo "OPTION"
-  ${ECHO} %b "-s		If you add -s option, add ${COLOR_CYAN}~/Library/Developer/Xcode/iOS DeviceSupport${COLOR_OFF} to be deleted.\n"
-  ${ECHO} %b "-b		If you add -b option, add ${COLOR_CYAN}~/Library/Developer/Xcode/Archives${COLOR_OFF} to be deleted.\n"
+  ${ECHO} %b "-d		If you add -d option, you will delete ${COLOR_CYAN}~/Library/Developer/Xcode/DerivedData${COLOR_OFF}.\n"
+  ${ECHO} %b "-s		If you add -s option, you will delete ${COLOR_CYAN}~/Library/Developer/Xcode/iOS DeviceSupport${COLOR_OFF}.\n"
+  ${ECHO} %b "-b		If you add -b option, you will delete ${COLOR_CYAN}~/Library/Developer/Xcode/Archives${COLOR_OFF}.\n"
   echo "-h, --help	show help"
   echo "    --version	show version"
   echo "-n, --dry-run	display the size to be deleted"
@@ -174,28 +188,48 @@ do
     echo
     ${ECHO} "${WHITE_UNDER}Display size to be deleted.${COLOR_OFF}\n"
     echo
-    ## dry-runの時はすべてのディレクトリを追加
-    DIRS+=",${DEVICE_SUPPORT_DIR}"
-    DIRS+=",${ARCHIVE_DIR}"
     showSizeMessage
     exit 0
     ;;
   # iOS DeviceSupportを削除対象に追加
   '-s' )
-    DIRS+=",${DEVICE_SUPPORT_DIR}"
-    IS_CONTAIN_DEVICE_SUPPORT=true
+    DIRS="${DEVICE_SUPPORT_DIR}"
+    IS_CONTAIN_ARCHIVE=false
+    IS_CONTAIN_DERIVED_DIR=false
     ;;
   # Archivesを削除対象に追加
   '-b' )
-    DIRS+=",${ARCHIVE_DIR}"
-    IS_CONTAIN_ARCHIVE=true
+    DIRS="${ARCHIVE_DIR}"
+    IS_CONTAIN_DEVICE_SUPPORT=false
+    IS_CONTAIN_DERIVED_DIR=false
+    ;;
+  # Derivedwo削除対象に追加
+  '-d' )
+    DIRS="${DERIVED_DATA_DIR}"
+    IS_CONTAIN_DEVICE_SUPPORT=false
+    IS_CONTAIN_ARCHIVE=false
     ;;
   # sとb(ちょっといけてないけど)
   '-sb' | '-bs' )
-    DIRS+=",${DEVICE_SUPPORT_DIR}"
-    IS_CONTAIN_DEVICE_SUPPORT=true
+    DIRS="${DEVICE_SUPPORT_DIR}"
     DIRS+=",${ARCHIVE_DIR}"
-    IS_CONTAIN_ARCHIVE=true
+    IS_CONTAIN_DERIVED_DIR=false
+    ;;
+  # sとd(ちょっといけてないけど)
+  '-sd' | '-ds' )
+    DIRS="${DEVICE_SUPPORT_DIR}"
+    DIRS+=",${DERIVED_DATA_DIR}"
+    IS_CONTAIN_ARCHIVE=false
+    ;;
+  # bとd(ちょっといけてないけど)
+  '-bd' | '-db' )
+    DIRS="${ARCHIVE_DIR}"
+    DIRS+=",${DERIVED_DATA_DIR}"
+    IS_CONTAIN_DEVICE_SUPPORT=false
+    ;;
+  # sとbとd(ちょっといけてないけど)
+  '-sbd' | '-sdb' | '-dsb' | '-dbs' | '-bsd' | '-bds' )
+    # 全指定と同じ
     ;;
   * )
     usage
@@ -206,13 +240,15 @@ done
 # メイン処理
 echo
 ${ECHO} "${WHITE_UNDER}This script will clean the cache of Xcode.${COLOR_OFF}\n"
+echo
 if ! $IS_CONTAIN_DEVICE_SUPPORT ; then
-  echo
   ${ECHO} %b "✏️${COLOR_GRAY} If you add ${COLOR_OFF}-s${COLOR_GRAY} option, add ~/Library/Developer/Xcode/iOS DeviceSupport to be deleted.${COLOR_OFF}\n"
 fi
 if ! $IS_CONTAIN_ARCHIVE ; then
-  echo
   ${ECHO} %b "✏️${COLOR_GRAY} If you add ${COLOR_OFF}-b${COLOR_GRAY} option, add ~/Library/Developer/Xcode/Archives to be deleted.${COLOR_OFF}\n"
+fi
+if ! $IS_CONTAIN_DERIVED_DIR ; then
+  ${ECHO} %b "✏️${COLOR_GRAY} If you add ${COLOR_OFF}-d${COLOR_GRAY} option, add ~/Library/Developer/Xcode/DerivedData to be deleted.${COLOR_OFF}\n"
 fi
 echo
 showSizeMessage

--- a/refreshXcode.rb
+++ b/refreshXcode.rb
@@ -20,8 +20,8 @@ class Refreshxcode < Formula
   # For integrity and security, we verify the hash (`openssl dgst -sha1 <FILE>`)
   # You may also use sha256 if the software uses sha256 on their homepage.
   # Leave it empty at first and `brew install` will tell you the expected.
-  sha256 "8f6cc06dbdc7383dbceab1b2e17501cdbf2a1edd"
-  version "1.6"
+  sha256 "18b93b06cc00afdb9ce9712768c4acb46b04d4e5"
+  version "1.7"
 
   def install
     bin.install "bin/refreshXcode"
@@ -30,12 +30,25 @@ class Refreshxcode < Formula
     <<~EOF
     Usage: refreshXcode [OPTION]
 
-    The default behavior is to delete ~/Library/Developer/Xcode/DerivedData.
-    You can add directories to be deleted with the options.
-
+    The default behavior is to delete the following directories.
+     ~/Library/Developer/Xcode/DerivedData
+     ~/Library/Developer/Xcode/iOS DeviceSupport
+     ~/Library/Developer/Xcode/Archives
+    
+    You can also delete them individually by specifying options.
+    
+    e.g.
+    
+    Only ~/Library/Developer/Xcode/DerivedData
+    $ refreshXcode -s
+    
+    ~/Library/Developer/Xcode/DerivedData and ~/Library/Developer/Xcode/Archives
+    $ refreshXcode -sb
+    
     OPTION
-    -s		If you add -s option, add ~/Library/Developer/Xcode/iOS DeviceSupport to be deleted.
-    -b		If you add -b option, add ~/Library/Developer/Xcode/Archives to be deleted.
+    -d		If you add -d option, you will delete ~/Library/Developer/Xcode/DerivedData.
+    -s		If you add -s option, you will delete ~/Library/Developer/Xcode/iOS DeviceSupport.
+    -b		If you add -b option, you will delete ~/Library/Developer/Xcode/Archives.
     -h, --help      show help
         --version   show version
     -n, --dry-run   display the size to be deleted


### PR DESCRIPTION
## 概要

デフォルトで以下のディレクトリを削除

- ~/Library/Developer/Xcode/DerivedData
- ~/Library/Developer/Xcode/iOS DeviceSupport
- ~/Library/Developer/Xcode/Archives

オプションで個別に選べるようにした
-s -b -d